### PR TITLE
Fixed wrong android version name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you need to change progress state:
 ```
 #Compatibility
   
-  * Android GINGERBREAD 3.0+
+  * Android HONEYCOMB 3.0+
   
 # Changelog
 


### PR DESCRIPTION
The name of Android 3.0 (API 11) is HONEYCOMB not GINGERBREAD
