### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you need to change progress state:
 
 ##Installing with [Gradle](http://gradle.org/)
 ```groovy
-compile 'com.github.yalantis:taurus:1.0.2'
+implementation 'com.github.yalantis:taurus:1.0.2'
 ```
 
 #Compatibility


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.